### PR TITLE
Add regex for scheme validation

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -34,7 +34,8 @@ class Url implements UriInterface
     /** @var string */
     protected $fragment = '';
 
-    const VALID_SCHEMES = ['http', 'https', 'mailto'];
+    /** @var string */
+    const VALID_SCHEME_REGEX = '/^[a-zA-Z][a-zA-Z0-9+.-]{1,}/';
 
     public function __construct()
     {
@@ -214,7 +215,7 @@ class Url implements UriInterface
     {
         $scheme = strtolower($scheme);
 
-        if (! in_array($scheme, static::VALID_SCHEMES)) {
+        if (! preg_match(static::VALID_SCHEME_REGEX, $scheme)) {
             throw InvalidArgument::invalidScheme($scheme);
         }
 

--- a/tests/UrlBuildTest.php
+++ b/tests/UrlBuildTest.php
@@ -24,6 +24,12 @@ class UrlBuildTest extends TestCase
             ->withHost('spatie.be');
 
         $this->assertEquals('https://spatie.be', $url->__toString());
+
+        $url = Url::create()
+            ->withScheme('applewebdata')
+            ->withHost('spatie.be');
+
+        $this->assertEquals('applewebdata://spatie.be', $url->__toString());
     }
 
     /** @test */
@@ -38,9 +44,9 @@ class UrlBuildTest extends TestCase
     public function it_throws_an_exception_when_providing_an_invalid_url_scheme()
     {
         $this->expectException(InvalidArgument::class);
-        $this->expectExceptionMessage(InvalidArgument::invalidScheme('htps')->getMessage());
+        $this->expectExceptionMessage(InvalidArgument::invalidScheme('123invalidshemehtps')->getMessage());
 
-        Url::create()->withScheme('htps');
+        Url::create()->withScheme('123invalidshemehtps');
     }
 
     /** @test */

--- a/tests/UrlParseTest.php
+++ b/tests/UrlParseTest.php
@@ -36,9 +36,9 @@ class UrlParseTest extends TestCase
     public function it_throws_an_exception_if_an_invalid_scheme_is_provided()
     {
         $this->expectException(InvalidArgument::class);
-        $this->expectExceptionMessage(InvalidArgument::invalidScheme('htps')->getMessage());
+        $this->expectExceptionMessage(InvalidArgument::invalidScheme('123invalidshemehtps')->getMessage());
 
-        Url::fromString('htps://spatie.be');
+        Url::fromString('123invalidshemehtps://spatie.be');
     }
 
     /** @test */


### PR DESCRIPTION
This updates sanitizing the scheme.

According to https://tools.ietf.org/html/rfc3986#section-3.1

```
   Scheme names consist of a sequence of characters beginning with a
   letter and followed by any combination of letters, digits, plus
   ("+"), period ("."), or hyphen ("-").  Although schemes are case-
   insensitive, the canonical form is lowercase and documents that
   specify schemes must do so with lowercase letters.  An implementation
```

Which I've matched with the regex:
`'/^[a-zA-Z][a-zA-Z0-9+.-]{1,}/'`

(I'm by no means a regex expert so please double check or see if there is room for improvement).

This fixes #24 
