### PR TITLE
Preserve trailing slash in URL path

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -327,7 +327,9 @@ class Url implements UriInterface
             $url .= $this->getAuthority();
         }
 
-        $url .= rtrim($this->getPath(), '/');
+        if ($this->getPath() !== '/') {
+            $url .= $this->getPath();
+        }
 
         if ($this->getQuery() !== '') {
             $url .= '?'.$this->getQuery();

--- a/tests/UrlBuildTest.php
+++ b/tests/UrlBuildTest.php
@@ -84,6 +84,16 @@ class UrlBuildTest extends TestCase
     }
 
     /** @test */
+    public function it_preserves_a_trailing_slash_in_the_path()
+    {
+        $url = Url::create()
+            ->withHost('spatie.be')
+            ->withPath('opensource/');
+
+        $this->assertEquals('//spatie.be/opensource/', (string) $url);
+    }
+
+    /** @test */
     public function it_prefixes_paths_with_a_slash_if_its_not_present()
     {
         $url = Url::create()

--- a/tests/UrlMatchesTest.php
+++ b/tests/UrlMatchesTest.php
@@ -24,6 +24,14 @@ class UrlMatchesTest extends TestCase
     }
 
     /** @test */
+    public function it_differentiates_between_urls_with_trailing_slash()
+    {
+        $url = Url::fromString('https://spatie.be/opensource/');
+
+        $this->assertFalse($url->matches(Url::fromString('https://spatie.be/opensource')));
+    }
+
+    /** @test */
     public function it_can_check_if_it_contains_a_mailto()
     {
         $url = Url::fromString('mailto:email@domain.tld');

--- a/tests/UrlParseTest.php
+++ b/tests/UrlParseTest.php
@@ -58,6 +58,14 @@ class UrlParseTest extends TestCase
     }
 
     /** @test */
+    public function it_preserves_a_trailing_slash_in_the_path()
+    {
+        $url = Url::fromString('https://spatie.be/opensource/');
+
+        $this->assertEquals('/opensource/', $url->getPath());
+    }
+
+    /** @test */
     public function it_can_parse_an_empty_path()
     {
         $url = Url::fromString('https://spatie.be');


### PR DESCRIPTION
This aims to resolve https://github.com/spatie/url/issues/19 and https://github.com/spatie/laravel-uptime-monitor/issues/195.

The previous behavior unconditionally stripped a trailing slash from all URLs, which resulted in parsed URLs differing from the original:

    http://example.com/path/ -> http://example.com/path

Now the original URL is preserved. Furthermore, these two URLs are no longer considered to be equal by the `matches()` method.

However, a trailing slash is still stripped from an "empty" path, which is in keeping with the original behavior:

    http://example.com/ -> http://example.com

#### Notes

- Added test coverage for relevant cases.
- Did not update any documentation, as the previous behavior was unexpected and undocumented (except for a mention in the change log here: https://github.com/spatie/url/blob/master/CHANGELOG.md#101---2016-11-14)

Thanks!