### PR TITLE
Direct query manipulation

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -146,6 +146,7 @@ class Url implements UriInterface
     public function addQueryParameter(string $key, string $value)
     {
         $this->query->unset($key);
+        
         $this->query->set($key, $value);
 
         return $this;

--- a/src/Url.php
+++ b/src/Url.php
@@ -143,6 +143,14 @@ class Url implements UriInterface
         return $this->query->all();
     }
 
+    public function addQueryParameter(string $key, string $value)
+    {
+        $this->query->unset($key);
+        $this->query->set($key, $value);
+
+        return $this;
+    }
+
     public function withQueryParameter(string $key, string $value)
     {
         $url = clone $this;
@@ -151,6 +159,13 @@ class Url implements UriInterface
         $url->query->set($key, $value);
 
         return $url;
+    }
+
+    public function removeQueryParameter(string $key, string $value)
+    {
+        $this->query->unset($key);
+
+        return $this;
     }
 
     public function withoutQueryParameter(string $key)


### PR DESCRIPTION
I assumed this was built in and was a little suprised that I need to re-save the object with the updated query. This adds the option to edit the URL object query directly without handling the returned object.