### PR TITLE
urlencode() new query params values

### DIFF
--- a/src/QueryParameterBag.php
+++ b/src/QueryParameterBag.php
@@ -59,7 +59,7 @@ class QueryParameterBag
     public function __toString()
     {
         $keyValuePairs = Arr::map($this->parameters, function ($value, $key) {
-            return "{$key}={$value}";
+            return "{$key}=".urlencode($value);
         });
 
         return implode('&', $keyValuePairs);

--- a/src/QueryParameterBag.php
+++ b/src/QueryParameterBag.php
@@ -59,7 +59,7 @@ class QueryParameterBag
     public function __toString()
     {
         $keyValuePairs = Arr::map($this->parameters, function ($value, $key) {
-            return "{$key}=".urlencode($value);
+            return "{$key}=".rawurlencode($value);
         });
 
         return implode('&', $keyValuePairs);

--- a/src/QueryParameterBag.php
+++ b/src/QueryParameterBag.php
@@ -23,7 +23,9 @@ class QueryParameterBag
         return new static(Arr::mapToAssoc(explode('&', $query), function (string $keyValue) {
             $parts = explode('=', $keyValue, 2);
 
-            return count($parts) === 2 ? $parts : [$parts[0], null];
+            return count($parts) === 2
+                ? [$parts[0], rawurldecode($parts[1])]
+                : [$parts[0], null];
         }));
     }
 

--- a/src/Url.php
+++ b/src/Url.php
@@ -148,7 +148,7 @@ class Url implements UriInterface
         $url = clone $this;
         $url->query->unset($key);
 
-        $url->query->set($key, urlencode($value));
+        $url->query->set($key, $value);
 
         return $url;
     }

--- a/src/Url.php
+++ b/src/Url.php
@@ -148,7 +148,7 @@ class Url implements UriInterface
         $url = clone $this;
         $url->query->unset($key);
 
-        $url->query->set($key, $value);
+        $url->query->set($key, urlencode($value));
 
         return $url;
     }

--- a/tests/QueryParameterBagTest.php
+++ b/tests/QueryParameterBagTest.php
@@ -94,6 +94,17 @@ class QueryParameterBagTest extends TestCase
     }
 
     /** @test */
+    public function it_can_be_created_from_a_string_with_url_encoded_values()
+    {
+        $queryParameterBag = QueryParameterBag::fromString(
+            'category=storage%20furniture&discount=%3E40%25%20off'
+        );
+
+        $this->assertEquals('storage furniture', $queryParameterBag->get('category'));
+        $this->assertEquals('>40% off', $queryParameterBag->get('discount'));
+    }
+
+    /** @test */
     public function it_url_encodes_values_when_being_casted_to_a_string()
     {
         $queryParameterBag = new QueryParameterBag([]);

--- a/tests/QueryParameterBagTest.php
+++ b/tests/QueryParameterBagTest.php
@@ -92,4 +92,18 @@ class QueryParameterBagTest extends TestCase
 
         $this->assertEquals('offset=10&limit=20', $queryParameterBag->__toString());
     }
+
+    /** @test */
+    public function it_url_encodes_values_when_being_casted_to_a_string()
+    {
+        $queryParameterBag = new QueryParameterBag([]);
+
+        $queryParameterBag->set('category', 'storage furniture');
+        $queryParameterBag->set('discount', '>40% off');
+
+        $this->assertEquals(
+            'category=storage%20furniture&discount=%3E40%25%20off',
+            $queryParameterBag->__toString()
+        );
+    }
 }


### PR DESCRIPTION
Hi guys 👋🏼
I'm making this PR in part to signal the bug, because maybe there's a better solution.
We've had a bunch of reports from links not working correctly and nailed it down to the query parameters not being URL encoded.
- Fails: https://mysite.com/filter?category=cute cats
- Works: https://mysite.com/filter?category=cute%20cats

Of course, it's the same for `&`, `?`, etc

So basically I just added `urlencode()` to `withQueryParameter()`.

What do you think? Ever had this issue?