### PR TITLE
Improve some testing stuffs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,5 +31,10 @@ jobs:
             - name: Install dependencies
               run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
-            - name: Execute tests
+            - name: Execute tests on Ubuntu OS
+              if: matrix.operating-system == 'ubuntu-latest'
+              run: XDEBUG_MODE=coverage vendor/bin/phpunit
+
+            - name: Execute tests on Windows OS
+              if: matrix.operating-system == 'windows-latest'
               run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+.phpunit.result.cache

--- a/tests/QueryParameterBagTest.php
+++ b/tests/QueryParameterBagTest.php
@@ -46,7 +46,7 @@ class QueryParameterBagTest extends TestCase
 
         $queryParameterBag->set('offset', 10);
 
-        $this->assertEquals(10, $queryParameterBag->get('offset'));
+        $this->assertSame('10', $queryParameterBag->get('offset'));
     }
 
     /** @test */
@@ -73,8 +73,8 @@ class QueryParameterBagTest extends TestCase
     {
         $queryParameterBag = QueryParameterBag::fromString('offset=10&limit=20');
 
-        $this->assertEquals(10, $queryParameterBag->get('offset'));
-        $this->assertEquals(20, $queryParameterBag->get('limit'));
+        $this->assertSame('10', $queryParameterBag->get('offset'));
+        $this->assertSame('20', $queryParameterBag->get('limit'));
     }
 
     /** @test */

--- a/tests/UrlBuildTest.php
+++ b/tests/UrlBuildTest.php
@@ -13,7 +13,7 @@ class UrlBuildTest extends TestCase
     {
         $url = Url::create()->withHost('spatie.be');
 
-        $this->assertEquals('//spatie.be', $url);
+        $this->assertSame('//spatie.be', (string) $url);
     }
 
     /** @test */

--- a/tests/UrlImmutableTest.php
+++ b/tests/UrlImmutableTest.php
@@ -47,7 +47,7 @@ class UrlImmutableTest extends TestCase
 
         $clone = $url->withPort(9000);
 
-        $this->assertEquals(0, $url->getPort());
+        $this->assertNull($url->getPort());
         $this->assertEquals(9000, $clone->getPort());
     }
 

--- a/tests/UrlQueryParametersTest.php
+++ b/tests/UrlQueryParametersTest.php
@@ -12,7 +12,7 @@ class UrlQueryParametersTest extends TestCase
     {
         $url = Url::create()->withQuery('offset=10');
 
-        $this->assertEquals(10, $url->getQueryParameter('offset'));
+        $this->assertSame('10', $url->getQueryParameter('offset'));
     }
 
     /** @test */
@@ -44,7 +44,7 @@ class UrlQueryParametersTest extends TestCase
     {
         $url = Url::create()->withQueryParameter('offset', 10);
 
-        $this->assertEquals(10, $url->getQueryParameter('offset'));
+        $this->assertSame('10', $url->getQueryParameter('offset'));
     }
 
     /** @test */


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to assert value equals strict.
- Adding the `XDEBUG_MODE` variable for `vendor/bin/phpunit` on Ubuntu OS to fix following warning message:

```
Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set
```
- The `.phpunit.result.cache` file is cached PHPUnit result file and it should be ignored on Git version control.