### PR TITLE
Add ability to add multiple query parameters at once

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -153,6 +153,17 @@ class Url implements UriInterface
         return $url;
     }
 
+    public function withQueryParameters(array $parameters)
+    {
+        $url = $this;
+
+        foreach ($parameters as $key => $value) {
+            $url = $url->withQueryParameter($key, $value);
+        }
+
+        return $url;
+    }
+
     public function withoutQueryParameter(string $key)
     {
         $url = clone $this;

--- a/tests/UrlQueryParametersTest.php
+++ b/tests/UrlQueryParametersTest.php
@@ -48,6 +48,15 @@ class UrlQueryParametersTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_query_parameters()
+    {
+        $url = Url::create()->withQueryParameters(['offset' => 10, 'limit' => 5]);
+
+        $this->assertSame('10', $url->getQueryParameter('offset'));
+        $this->assertSame('5', $url->getQueryParameter('limit'));
+    }
+
+    /** @test */
     public function it_can_check_if_it_has_a_query_parameter()
     {
         $url = Url::create()->withQuery('offset=10');


### PR DESCRIPTION
Having multiple query parameters to set in the query string can be a little bit heavy if they must be set one by one using `withQueryParameter`.

```php
Url::fromString($baseUrl)
    ->withQueryParameter('page', $page)
    ->withQueryParameter('per_page', $perPage)
    ->withQueryParameter('filter', $filter)
    ->withQueryParameter('order_by', $orderBy)
    ->withQueryParameter('direction, $direction);
```

This PR add ability to give an array of parameters to add to the query, which IMHO looks lighter

```php
Url::fromString($baseUrl)
    ->withQueryParameters([
        'page' =>  $page,
        'per_page' =>  $perPage,
        'filter' =>  $filter,
        'order_by' =>  $orderBy,
        'direction' =>  $direction,
    ]);
```

