### PR TITLE
Remove prefixing `/` for `mailto:` schemes when building `withPath()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All Notable changes to `url` will be documented in this file
 
+## 2.0.1 - 2021-06-24
+- Remove prefixing `/` for `mailto:` schemes when building `withPath()`
+
 ## 2.0.0 - 2021-03-31
 
 - require PHP 8+

--- a/src/Url.php
+++ b/src/Url.php
@@ -320,7 +320,11 @@ class Url implements UriInterface
         }
 
         if ($this->getPath() !== '/') {
-            $url .= $this->getPath();
+            $path = $this->getScheme() === 'mailto'
+                ? ltrim($this->getPath(), '/')
+                : $this->getPath();
+
+            $url .= $path;
         }
 
         if ($this->getQuery() !== '') {

--- a/tests/UrlBuildTest.php
+++ b/tests/UrlBuildTest.php
@@ -27,6 +27,21 @@ class UrlBuildTest extends TestCase
     }
 
     /** @test */
+    public function it_can_build_a_url_with_a_mailto()
+    {
+        $url = Url::create()
+            ->withScheme('mailto')
+            ->withUserInfo('spatie')
+            ->withPath('spatie.be');
+
+        $this->assertNotEquals('mailto:spatie@/spatie.be', (string) $url);
+        $this->assertEquals('mailto:spatie@spatie.be', (string) $url);
+
+        // @TODO Incorrect, but fixing conflicts with backward compatibility.
+        $this->assertEquals('/spatie.be', $url->getPath());
+    }
+
+    /** @test */
     public function it_can_convert_itself_back_to_a_string()
     {
         $url = Url::fromString('https://spatie.be/');

--- a/tests/UrlParseTest.php
+++ b/tests/UrlParseTest.php
@@ -33,6 +33,14 @@ class UrlParseTest extends TestCase
     }
 
     /** @test */
+    public function it_can_parse_a_path_with_mailto()
+    {
+        $url = Url::fromString('mailto:email@domain.tld');
+
+        $this->assertEquals('email@domain.tld', $url->getPath());
+    }
+
+    /** @test */
     public function it_throws_an_exception_if_an_invalid_scheme_is_provided()
     {
         $this->expectException(InvalidArgument::class);


### PR DESCRIPTION
To keep backwards incompatibility I just trimmed the string during the build.  Otherwise getPath would have to be context aware of the scheme and I didn't want to set that precedent in a patch.