### PR TITLE
PHP 8.1 Compatibility

### DIFF
--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -13,9 +13,9 @@ class Arr
         return array_combine($keys, $items);
     }
 
-    public static function mapToAssoc(array $items, callable $callback): mixed
+    public static function mapToAssoc(array $items, callable $callback): array
     {
-        return array_reduce($items, function (array $assoc, $item) use ($callback) {
+        return array_reduce($items, function (array $assoc, $item) use ($callback): array {
             [$key, $value] = $callback($item);
             $assoc[$key] = $value;
 

--- a/src/QueryParameterBag.php
+++ b/src/QueryParameterBag.php
@@ -4,7 +4,7 @@ namespace Spatie\Url;
 
 use Spatie\Url\Helpers\Arr;
 
-class QueryParameterBag
+class QueryParameterBag implements \Stringable
 {
     public function __construct(
         protected array $parameters = [],

--- a/src/QueryParameterBag.php
+++ b/src/QueryParameterBag.php
@@ -18,7 +18,8 @@ class QueryParameterBag implements \Stringable
             return new static();
         }
 
-        return new static(Arr::mapToAssoc(explode('&', $query), function (string $keyValue) {
+        return new static(Arr::mapToAssoc(explode('&', $query), function (string $keyValue): array
+        {
             $parts = explode('=', $keyValue, 2);
 
             return count($parts) === 2
@@ -60,7 +61,7 @@ class QueryParameterBag implements \Stringable
     {
         $keyValuePairs = Arr::map(
             $this->parameters,
-            fn ($value, $key) => "{$key}=".rawurlencode($value)
+            fn ($value, $key): string => "{$key}=".rawurlencode($value)
         );
 
         return implode('&', $keyValuePairs);

--- a/src/Url.php
+++ b/src/Url.php
@@ -5,8 +5,9 @@ namespace Spatie\Url;
 use Psr\Http\Message\UriInterface;
 use Spatie\Macroable\Macroable;
 use Spatie\Url\Exceptions\InvalidArgument;
+use Stringable;
 
-class Url implements UriInterface
+class Url implements UriInterface, Stringable
 {
     use Macroable;
 

--- a/src/Url.php
+++ b/src/Url.php
@@ -123,7 +123,7 @@ class Url implements UriInterface, Stringable
         return (string) $this->query;
     }
 
-    public function getQueryParameter(string $key, $default = null): mixed
+    public function getQueryParameter(string $key, mixed $default = null): mixed
     {
         return $this->query->get($key, $default);
     }
@@ -138,7 +138,7 @@ class Url implements UriInterface, Stringable
         return $this->query->all();
     }
 
-    public function withQueryParameter(string $key, string $value): self
+    public function withQueryParameter(string $key, string $value): static
     {
         $url = clone $this;
         $url->query->unset($key);
@@ -148,7 +148,7 @@ class Url implements UriInterface, Stringable
         return $url;
     }
 
-    public function withoutQueryParameter(string $key): self
+    public function withoutQueryParameter(string $key): static
     {
         $url = clone $this;
         $url->query->unset($key);
@@ -196,7 +196,7 @@ class Url implements UriInterface, Stringable
         return end($segments) ?? null;
     }
 
-    public function withScheme($scheme): self
+    public function withScheme($scheme): static
     {
         $url = clone $this;
 
@@ -216,7 +216,7 @@ class Url implements UriInterface, Stringable
         return $scheme;
     }
 
-    public function withUserInfo($user, $password = null): self
+    public function withUserInfo($user, $password = null): static
     {
         $url = clone $this;
 
@@ -226,7 +226,7 @@ class Url implements UriInterface, Stringable
         return $url;
     }
 
-    public function withHost($host): self
+    public function withHost($host): static
     {
         $url = clone $this;
 
@@ -235,7 +235,7 @@ class Url implements UriInterface, Stringable
         return $url;
     }
 
-    public function withPort($port): self
+    public function withPort($port): static
     {
         $url = clone $this;
 
@@ -244,7 +244,7 @@ class Url implements UriInterface, Stringable
         return $url;
     }
 
-    public function withPath($path): self
+    public function withPath($path): static
     {
         $url = clone $this;
 
@@ -257,7 +257,7 @@ class Url implements UriInterface, Stringable
         return $url;
     }
 
-    public function withDirname(string $dirname): self
+    public function withDirname(string $dirname): static
     {
         $dirname = trim($dirname, '/');
 
@@ -268,7 +268,7 @@ class Url implements UriInterface, Stringable
         return $this->withPath($dirname.'/'.$this->getBasename());
     }
 
-    public function withBasename(string $basename): self
+    public function withBasename(string $basename): static
     {
         $basename = trim($basename, '/');
 
@@ -279,7 +279,7 @@ class Url implements UriInterface, Stringable
         return $this->withPath($this->getDirname().'/'.$basename);
     }
 
-    public function withQuery($query): self
+    public function withQuery($query): static
     {
         $url = clone $this;
 
@@ -288,7 +288,7 @@ class Url implements UriInterface, Stringable
         return $url;
     }
 
-    public function withFragment($fragment): self
+    public function withFragment($fragment): static
     {
         $url = clone $this;
 


### PR DESCRIPTION
This pull request will add the `\Stringable` interface for classes which are implementing the `__toString` method and provide native parameter as well as return type hints where applicable and add return types which are specified in the `Psr\Http\Message\UriInterface`.