### PR TITLE
Add ability to set multiple query parameters at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ $url = Url::fromString('https://spatie.be/opensource?utm_source=github&utm_campa
 echo $url->getQuery(); // 'utm_source=github&utm_campaign=packages'
 echo $url->getQueryParameter('utm_source'); // 'github'
 echo $url->withoutQueryParameter('utm_campaign'); // 'https://spatie.be/opensource?utm_source=github'
+echo $url->withQueryParameters(['utm_campaign' => 'packages']); // 'https://spatie.be/opensource?utm_source=github&utm_campaign=packages'
 ```
 
 Retrieve path segments:

--- a/src/Url.php
+++ b/src/Url.php
@@ -148,6 +148,15 @@ class Url implements UriInterface, Stringable
         return $url;
     }
 
+    public function withQueryParameters(array $parameters): static
+    {
+        $parameters = array_merge($this->getAllQueryParameters(), $parameters);
+        $url = clone $this;
+        $url->query = new QueryParameterBag($parameters);
+
+        return $url;
+    }
+
     public function withoutQueryParameter(string $key): static
     {
         $url = clone $this;

--- a/tests/UrlQueryParametersTest.php
+++ b/tests/UrlQueryParametersTest.php
@@ -48,6 +48,24 @@ class UrlQueryParametersTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_multiple_query_parameters()
+    {
+        $url = Url::create()->withQueryParameters(['offset' => 10, 'limit' => 5]);
+
+        $this->assertEquals('10', $url->getQueryParameter('offset'));
+        $this->assertEquals('5', $url->getQueryParameter('limit'));
+    }
+
+    /** @test */
+    public function it_merges_multiple_query_parameters()
+    {
+        $url = Url::create()->withQuery('offset=10')->withQueryParameters(['limit' => 5]);
+
+        $this->assertTrue($url->hasQueryParameter('offset'));
+        $this->assertTrue($url->hasQueryParameter('limit'));
+    }
+
+    /** @test */
     public function it_can_check_if_it_has_a_query_parameter()
     {
         $url = Url::create()->withQuery('offset=10');


### PR DESCRIPTION
Inspired by https://github.com/spatie/url/pull/43

> Having multiple query parameters to set in the query string can be a little bit heavy if they must be set one by one using `withQueryParameter()`.
> 
> ```php
> Url::fromString($baseUrl)
>     ->withQueryParameter('page', $page)
>     ->withQueryParameter('per_page', $perPage)
>     ->withQueryParameter('filter', $filter)
>     ->withQueryParameter('order_by', $orderBy)
>     ->withQueryParameter('direction, $direction);
> ```
> 
> This PR adds the ability to supply an array of parameters to add to the query. This helps improve developer experience, especially if the query string is already stored in variable.
> 
> ```php
> Url::fromString($baseUrl)
>     ->withQueryParameters([
>         'page' =>  $page,
>         'per_page' =>  $perPage,
>         'filter' =>  $filter,
>         'order_by' =>  $orderBy,
>         'direction' =>  $direction,
>     ]);
> ```

An example, when the parameters are within an array variable.

```php
$serverGeneratedParameters = Foo::getArbitraryParameters(); // these may be global UTM parameters, or similar

$url = Url::fromString($baseUrl);
foreach ($serverGeneratedParameters as $key => $value) {
    $url = $url->withQueryParameter($key, $value);
}
```

vs

```php
$serverGeneratedParameters = Foo::getArbitraryParameters(); // for example, these may be global UTM parameters, or similar

$url = Url::fromString($baseUrl)->withQueryParameters($serverGeneratedParameters);
```