### PR TITLE
Add withoutQueryParameters & unsetAll method

### DIFF
--- a/src/QueryParameterBag.php
+++ b/src/QueryParameterBag.php
@@ -47,6 +47,13 @@ class QueryParameterBag implements \Stringable
         return $this;
     }
 
+    public function unsetAll(): self
+    {
+        $this->parameters = [];
+
+        return $this;
+    }
+
     public function all(): array
     {
         return $this->parameters;

--- a/src/Url.php
+++ b/src/Url.php
@@ -165,6 +165,14 @@ class Url implements UriInterface, Stringable
         return $url;
     }
 
+    public function withoutQueryParameters(): static
+    {
+        $url = clone $this;
+        $url->query->unsetAll();
+
+        return $url;
+    }
+
     public function getFragment(): string
     {
         return $this->fragment;

--- a/tests/QueryParameterBagTest.php
+++ b/tests/QueryParameterBagTest.php
@@ -106,3 +106,11 @@ it('url encodes values when being casted to a string', function () {
 
     expect($queryParameterBag)->__toString()->toEqual('category=storage%20furniture&discount=%3E40%25%20off&range%5B0%5D=10&range%5B1%5D=20');
 });
+
+it('unsets all query parameters', function () {
+   $queryParameterBag = QueryParameterBag::fromString(
+       'category=storage%20furniture&discount=%3E40%25%20off&range%5B0%5D=10&range%5B1%5D=20'
+   )->unsetAll();
+
+   expect($queryParameterBag)->all()->toEqual([]);
+});

--- a/tests/UrlQueryParametersTest.php
+++ b/tests/UrlQueryParametersTest.php
@@ -75,6 +75,11 @@ it('can unset all query parameters', function () {
         ->withoutQueryParameters();
 
     expect($url)->getAllQueryParameters()->toEqual([]);
+
+    $url = Url::fromString('https://example.com?foo=bar')
+        ->withoutQueryParameters();
+
+    expect((string) $url)->toEqual('https://example.com');
 });
 
 

--- a/tests/UrlQueryParametersTest.php
+++ b/tests/UrlQueryParametersTest.php
@@ -69,6 +69,14 @@ it('can unset a query parameter', function () {
     expect($url)->hasQueryParameter('offset')->toBeFalse();
 });
 
+it('can unset all query parameters', function () {
+    $url = Url::create()
+        ->withQuery('offset=10')
+        ->withoutQueryParameters();
+
+    expect($url)->getAllQueryParameters()->toEqual([]);
+});
+
 
 it('can handle empty query parameters', function () {
     $url = Url::create()->withQuery('offset');


### PR DESCRIPTION
Added new feature that allows `Url` instance to remove all query parameters.

```php
$url = Url::fromString('https://example.com?foo=bar')
        ->withoutQueryParameters();

echo (string) $url; // https://example.com
```