### PR TITLE
lazy evaluate Url::getQueryParameter default argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,15 @@ Retrieve and transform query parameters:
 $url = Url::fromString('https://spatie.be/opensource?utm_source=github&utm_campaign=packages');
 
 echo $url->getQuery(); // 'utm_source=github&utm_campaign=packages'
+
 echo $url->getQueryParameter('utm_source'); // 'github'
+echo $url->getQueryParameter('utm_medium'); // null
+echo $url->getQueryParameter('utm_medium', 'social'); // 'social'
+echo $url->getQueryParameter('utm_medium', function() {
+    //some logic
+    return 'email';
+}); // 'email'
+
 echo $url->withoutQueryParameter('utm_campaign'); // 'https://spatie.be/opensource?utm_source=github'
 echo $url->withQueryParameters(['utm_campaign' => 'packages']); // 'https://spatie.be/opensource?utm_source=github&utm_campaign=packages'
 ```

--- a/src/QueryParameterBag.php
+++ b/src/QueryParameterBag.php
@@ -25,7 +25,11 @@ class QueryParameterBag implements \Stringable
 
     public function get(string $key, mixed $default = null): mixed
     {
-        return $this->parameters[$key] ?? $default;
+        if ($this->has($key)) {
+            return $this->parameters[$key];
+        }
+
+        return is_callable($default) ? $default() : $default;
     }
 
     public function has(string $key): bool

--- a/tests/QueryParameterBagTest.php
+++ b/tests/QueryParameterBagTest.php
@@ -20,6 +20,9 @@ it('can return a default if a parameter doesnt exist', function () {
     $queryParameterBag = new QueryParameterBag(['offset' => 10]);
 
     expect($queryParameterBag)->get('limit', 20)->toEqual(20);
+    expect($queryParameterBag)->get('limit', function () {
+        return 100;
+    })->toEqual(100);
 });
 
 

--- a/tests/UrlQueryParametersTest.php
+++ b/tests/UrlQueryParametersTest.php
@@ -20,6 +20,9 @@ it('can return a default if a query parameter doesnt exist', function () {
     $url = Url::create()->withQuery('offset=10');
 
     expect($url)->getQueryParameter('limit', 20)->toEqual(20);
+    expect($url)->getQueryParameter('limit', function () {
+        return 100;
+    })->toEqual(100);
 });
 
 


### PR DESCRIPTION
This PR adds the ability to lazy evaluate Url::getQueryParameter "$default" argument.